### PR TITLE
Fix IndexError: index out of range

### DIFF
--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -382,7 +382,7 @@ class WeierstrassCurve(Curve):
         if xy[0] == 2:
             x = xy[1:1+size]
             x = int.from_bytes(x,'big')
-            y = self.y_recover(x,xy[1+size])  
+            y = self.y_recover(x,xy[size])  
         elif xy[0] == 4:
             x = xy[1:1+size]
             x = int.from_bytes(x,'big')    


### PR DESCRIPTION
Since xy is 1+size long the highest valid index is 1+(size-1) which equals size.