### PR TITLE
Fix Overflow Error

### DIFF
--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -23,6 +23,7 @@
 
 #python 2 compatibility
 from builtins import int,pow
+from math import ceil
 
 import binascii
 import random
@@ -356,7 +357,7 @@ class WeierstrassCurve(Curve):
         Returns
            bytes : encoded point [04 | x | y] or [02 | x | sign] 
         """
-        size = self.size>>3
+        size = ceil(self.size /)  # Prevent overflow error
         x = bytearray(P.x.to_bytes(size,'big'))
         y = bytearray(P.y.to_bytes(size,'big'))
         if compressed:
@@ -377,7 +378,7 @@ class WeierstrassCurve(Curve):
         Returns
            Point : decoded point
         """
-        size = self.size>>3
+        size = ceil(self.size / 8)  # Prevent overflow error
         xy    =  bytearray(eP)
         if xy[0] == 2:
             x = xy[1:1+size]
@@ -713,7 +714,7 @@ class MontgomeryCurve(Curve):
         Returns
            bytes : encoded point
         """
-        size = self.size>>3
+        size = ceil(self.size / 8)
         x = bytearray(P.x.to_bytes(size,'little'))
         return bytes(x)
 

--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -377,7 +377,7 @@ class WeierstrassCurve(Curve):
         Returns
            Point : decoded point
         """
-        size = self.size>>3 + bool(self.size % 8)  # Prevent overflow error
+        size = self.size>>3 + bool(self.size % 8)
         xy    =  bytearray(eP)
         if xy[0] == 2:
             x = xy[1:1+size]

--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -356,7 +356,7 @@ class WeierstrassCurve(Curve):
         Returns
            bytes : encoded point [04 | x | y] or [02 | x | sign] 
         """
-        size = self.size>>3 + bool(self.size % 8)
+        size = self.size>>3 + (1 if self.size % 8 else 0)
         x = bytearray(P.x.to_bytes(size,'big'))
         y = bytearray(P.y.to_bytes(size,'big'))
         if compressed:
@@ -377,7 +377,7 @@ class WeierstrassCurve(Curve):
         Returns
            Point : decoded point
         """
-        size = self.size>>3 + bool(self.size % 8)
+        size = self.size>>3 + (1 if self.size % 8 else 0)
         xy    =  bytearray(eP)
         if xy[0] == 2:
             x = xy[1:1+size]
@@ -713,7 +713,7 @@ class MontgomeryCurve(Curve):
         Returns
            bytes : encoded point
         """
-        size = self.size>>3 + bool(self.size % 8)
+        size = self.size>>3 + (1 if self.size % 8 else 0)
         x = bytearray(P.x.to_bytes(size,'little'))
         return bytes(x)
 

--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -356,7 +356,7 @@ class WeierstrassCurve(Curve):
         Returns
            bytes : encoded point [04 | x | y] or [02 | x | sign] 
         """
-        size = self.size>>3 + (1 if self.size % 8 else 0)
+        size = self.size>>3 + (not not self.size % 8)
         x = bytearray(P.x.to_bytes(size,'big'))
         y = bytearray(P.y.to_bytes(size,'big'))
         if compressed:
@@ -377,7 +377,7 @@ class WeierstrassCurve(Curve):
         Returns
            Point : decoded point
         """
-        size = self.size>>3 + (1 if self.size % 8 else 0)
+        size = self.size>>3 + (not not self.size % 8)
         xy    =  bytearray(eP)
         if xy[0] == 2:
             x = xy[1:1+size]
@@ -713,7 +713,7 @@ class MontgomeryCurve(Curve):
         Returns
            bytes : encoded point
         """
-        size = self.size>>3 + (1 if self.size % 8 else 0)
+        size = self.size>>3 + (not not self.size % 8)
         x = bytearray(P.x.to_bytes(size,'little'))
         return bytes(x)
 

--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -356,7 +356,7 @@ class WeierstrassCurve(Curve):
         Returns
            bytes : encoded point [04 | x | y] or [02 | x | sign] 
         """
-        size = self.size>>3 + (not not self.size % 8)
+        size = self.size+7 >> 3
         x = bytearray(P.x.to_bytes(size,'big'))
         y = bytearray(P.y.to_bytes(size,'big'))
         if compressed:
@@ -377,7 +377,7 @@ class WeierstrassCurve(Curve):
         Returns
            Point : decoded point
         """
-        size = self.size>>3 + (not not self.size % 8)
+        size = self.size+7 >> 3
         xy    =  bytearray(eP)
         if xy[0] == 2:
             x = xy[1:1+size]
@@ -713,7 +713,7 @@ class MontgomeryCurve(Curve):
         Returns
            bytes : encoded point
         """
-        size = self.size>>3 + (not not self.size % 8)
+        size = self.size+7 >> 3
         x = bytearray(P.x.to_bytes(size,'little'))
         return bytes(x)
 

--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -357,7 +357,7 @@ class WeierstrassCurve(Curve):
         Returns
            bytes : encoded point [04 | x | y] or [02 | x | sign] 
         """
-        size = ceil(self.size /)  # Prevent overflow error
+        size = ceil(self.size / 8)  # Prevent overflow error
         x = bytearray(P.x.to_bytes(size,'big'))
         y = bytearray(P.y.to_bytes(size,'big'))
         if compressed:

--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -356,7 +356,7 @@ class WeierstrassCurve(Curve):
         Returns
            bytes : encoded point [04 | x | y] or [02 | x | sign] 
         """
-        size = self.size >> 3 + bool(self.size % 8)
+        size = self.size>>3 + bool(self.size % 8)
         x = bytearray(P.x.to_bytes(size,'big'))
         y = bytearray(P.y.to_bytes(size,'big'))
         if compressed:

--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -23,7 +23,6 @@
 
 #python 2 compatibility
 from builtins import int,pow
-from math import ceil
 
 import binascii
 import random
@@ -357,7 +356,7 @@ class WeierstrassCurve(Curve):
         Returns
            bytes : encoded point [04 | x | y] or [02 | x | sign] 
         """
-        size = ceil(self.size / 8)  # Prevent overflow error
+        size = self.size >> 3 + bool(self.size % 8)
         x = bytearray(P.x.to_bytes(size,'big'))
         y = bytearray(P.y.to_bytes(size,'big'))
         if compressed:
@@ -378,7 +377,7 @@ class WeierstrassCurve(Curve):
         Returns
            Point : decoded point
         """
-        size = ceil(self.size / 8)  # Prevent overflow error
+        size = self.size>>3 + bool(self.size % 8)  # Prevent overflow error
         xy    =  bytearray(eP)
         if xy[0] == 2:
             x = xy[1:1+size]
@@ -714,7 +713,7 @@ class MontgomeryCurve(Curve):
         Returns
            bytes : encoded point
         """
-        size = ceil(self.size / 8)
+        size = self.size>>3 + bool(self.size % 8)
         x = bytearray(P.x.to_bytes(size,'little'))
         return bytes(x)
 


### PR DESCRIPTION
Hello,

Using the curve "secp521k1", I was running into seemingly random instances of an `OverflowError` when encoding/decoding the points. For troubleshooting, I went into `ecpy/curves.py` and modified the `encode_point` to print out the calculated size (`self.size >> 3`) and the ACTUAL size, in bits, of the X and Y coordinates of the point. I noticed that sometimes it was too small.

Reproduce:
```
>>> import random
>>> from ecpy.curves import Curve
>>>
>>> curve = Curve.get_curve("secp521r1")
>>> p = 7777777 * curve.generator
>>> curve.encode_point(p)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Austin Archer\AppData\Roaming\Python\Python38\site-packages\ecpy\curves.py", line 360, in encode_point
    x = bytearray(P.x.to_bytes(size,'big'))
OverflowError: int too big to convert
```

What I discovered was that around 50% of the time, the value `self.size >> 3` is insufficient by one byte. In order to remedy this, the proper size of the numbers should be calculated by using `ceil(self.size / 8)`, or a slightly faster method such as `size = self.size >> 3 + bool(self.size % 8)` which will result in the proper bit sizes each time.

This is an issue because the bit size of secp521k1 is 521, and 521 >> 3 is equal to 65, but 66 is often required.