### PR TITLE
Bug Fix: 'type' required as domain parameter for WeierstrassCurve, TwistedEdwardCurve and MontgomeryCurve

### DIFF
--- a/src/ecpy/curves.py
+++ b/src/ecpy/curves.py
@@ -326,7 +326,8 @@ class WeierstrassCurve(Curve):
     def __init__(self, domain):
         """ Built an new short Weierstrass curve with the provided parameters. """
         self._domain = {}
-        self._set(domain, ('name','type', 'size',
+        self._domain['type'] = curve_defs.WEIERSTRASS
+        self._set(domain, ('name', 'size',
                               'a','b','field','generator','order','cofactor'))
 
 
@@ -506,7 +507,8 @@ class TwistedEdwardCurve(Curve):
     def __init__(self, domain):
         """ Built an new short twisted Edward curve with the provided parameters.  """
         self._domain = {}
-        self._set(domain, ('name','type','size',
+        self._domain['type'] = curve_defs.TWISTEDEDWARD
+        self._set(domain, ('name','size',
                               'a','d','field','generator','order'))
 
     def _coord_size(self):
@@ -766,9 +768,10 @@ class MontgomeryCurve(Curve):
     """
 
     def __init__(self, domain):
-        """ Built an new short twisted Edward curve with the provided parameters.  """
+        """ Built an new short Montgomery curve with the provided parameters.  """
         self._domain = {}
-        self._set(domain, ('name','type','size',
+        self._domain['type'] = curve_defs.MONTGOMERY
+        self._set(domain, ('name','size',
                            'a','b','field','generator','order'))
         #inv4 = pow(4,p-2,p)
         #self.a24  = ((self.a+2)*inv4)%p


### PR DESCRIPTION
Hi,

I tried to define a TwistedEdwardCurve by hand, e.g.
```
from ecpy.curves import TwistedEdwardCurve

p_25519 = 2**255 - 19
a_25519 = -1
d_25519 = 0x52036cee2b6ffe738cc740797779e89800700a4d4141d8ab75eb4dca135978a3
Gx_25519 = 0x216936d3cd6e53fec0a4e231fdd6dc5c692cc7609525a7b2c9562d608f25d51a
Gy_25519 = 0x6666666666666666666666666666666666666666666666666666666666666658
q_25519 = 2**252 + 27742317777372353535851937790883648493

cv = TwistedEdwardCurve ({'name': 'myTECurve',
                          'size': 256,
                          'a': a_25519,
                          'd': d_25519,
                          'field': p_25519,
                          'generator': [Gx_25519, Gy_25519],
                          'order': q_25519})
```
but I got an error because the 'type' key was expected as a domain parameter.

Then I set 'type' inside the class initialization for WeierstrassCurve, TwistedEdwardCurve and MontgomeryCurve, so that as described in the documentation, it is not needed anymore as a parameter.